### PR TITLE
Added Google Promo Tab Features Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ Note that these projects have not been security tested by dotmailer. If you deve
 * [RSForm!Pro Joomla! - dotmailer integration](https://www.rsjoomla.com/blog/view/312-rsformpro-dotmailer-integration.html)
 * [dotmailer woocommerce integration](https://plugins.leewillis.co.uk/downloads/dotmailer-woocommerce/)
 * [Saleslogix / Infor CRM](https://github.com/dotmailer/saleslogix-connector)
+* [Easy Editor Extension Blocks for Google Promo Tab Features](https://github.com/cansinacarer/DotDigital-Editor-Extension-for-Google-Promo-Tab-Annotations)


### PR DESCRIPTION
This is the DotDigital [Easy Editor Extension](https://developer.dotdigital.com/docs/easy-editor-extension-schema) I built which adds no-code blocks in the email editor for configuring and inserting Microdata into emails to utilize [Google Promo Tab features](https://developers.google.com/gmail/promotab/overview) and display rich data in the recipient inboxes.